### PR TITLE
Improve exception handling

### DIFF
--- a/google-play.php
+++ b/google-play.php
@@ -71,7 +71,9 @@ class GooglePlay {
 	];
 	public function parseApplication($packageName) {
 	    $link="https://play.google.com/store/apps/details?id=".$packageName."&hl=en_US&gl=US";
-		$input=file_get_contents($link);
+		if ( ! $input = @file_get_contents($link) ) {
+		  return [];
+		}
 // 		file_put_contents("t.html", $input);
 		$values=[];
 		$values["packageName"]=$packageName;

--- a/google-play.php
+++ b/google-play.php
@@ -72,7 +72,7 @@ class GooglePlay {
 	public function parseApplication($packageName) {
 	    $link="https://play.google.com/store/apps/details?id=".$packageName."&hl=en_US&gl=US";
 		if ( ! $input = @file_get_contents($link) ) {
-		  return [];
+			return ['success'=>0,'message'=>'Google returned: '.$http_response_header[0]];
 		}
 // 		file_put_contents("t.html", $input);
 		$values=[];
@@ -84,7 +84,7 @@ class GooglePlay {
 			$values["name"]=trim(strip_tags($name["content"]));
 		}
 		else {
-		    return [];
+		    return ['success'=>0,'message'=>'No app data found'];
 			return $values;
 			$values["name"]=null;
 		}
@@ -191,6 +191,7 @@ class GooglePlay {
 		if($this->debug) {
 			print_r($values);
 		}
+		$values['success'] = 1;
 		return $values;
 	}
 


### PR DESCRIPTION
Two commits, in case you wish to cherry-pick:

* 5a07c85 simply "hides" the `PHP Warning` on a 404 if an app is not found, and directly returns an empty array
* df9bb95 introduces two new array keys and applies them where appropriate:
    * `success`: set to `1` if data was successfully retrieved, including all other keys as before
    * `message`: only added if `success==0`, giving details on what failed

I was tempted to add a third commit with some cleanup – but knowing my own code I thought you might wish to keep the "notes" :wink:

PS: Would love if summary and featureGraphic could be extracted as well, but it seems those are not contained in the scraped page. But if you wish I can check my old scraper for additional details like price, votes etc – just let me know.