### PR TITLE
Make it easier to read and maintain

### DIFF
--- a/google-play.php
+++ b/google-play.php
@@ -106,6 +106,8 @@ class GooglePlay {
 			$values["type"]=null;
 		}
 
+		$proto = json_decode($this->getRegVal('/data:(?<content>\[\[\[.+?). sideChannel: .*?\);<\/script/ims'));
+		$values["summary"] = $proto[0][10][1][1];
 		$values["description"] = $this->getRegVal('/itemprop="description"><span jsslot><div jsname="sngebd">(?<content>.*?)<\/div><\/span><div/i');
 		$values["icon"] = $this->getRegVal('/<div class="hkhL9e"><div class="xSyT2c"><img src="(?<content>[^\"]+)"/i');
 		$values["featureGraphic"] = preg_replace('!(.*)=w\d+.*!i','$1',$this->getRegVal('/<meta name="twitter:image" content="(?<content>[^\"]+)"/i'));

--- a/google-play.php
+++ b/google-play.php
@@ -3,7 +3,7 @@
 *
 * @Name : GooglePlayWebServiceAPI/google-play.php
 * @Version : 0.3
-* @Programmer : Max
+* @Programmer : Max & Izzy
 * @Date : 2020-10-19, 2020-10-25, 2020-10-29, 2020-10-30, 2020-12-05
 * @Released under : https://github.com/BaseMax/GooglePlayWebServiceAPI/blob/master/LICENSE
 * @Repository : https://github.com/BaseMax/GooglePlayWebServiceAPI

--- a/google-play.php
+++ b/google-play.php
@@ -70,23 +70,16 @@ class GooglePlay {
 		],
 	];
 	public function parseApplication($packageName) {
-	    $link="https://play.google.com/store/apps/details?id=".$packageName."&hl=en_US&gl=US";
-		if ( ! $input = @file_get_contents($link) ) {
+		$link="https://play.google.com/store/apps/details?id=".$packageName."&hl=en_US&gl=US";
+		if ( ! $this->input = @file_get_contents($link) ) {
 			return ['success'=>0,'message'=>'Google returned: '.$http_response_header[0]];
 		}
-// 		file_put_contents("t.html", $input);
 		$values=[];
 		$values["packageName"]=$packageName;
-        // print $link."\n";
-		preg_match('/itemprop="name">(?<content>.*?)<\/h1>/', $input, $name);
-// 		print_r($name);
-		if(isset($name["content"])) {
 			$values["name"]=trim(strip_tags($name["content"]));
 		}
 		else {
 		    return ['success'=>0,'message'=>'No app data found'];
-			return $values;
-			$values["name"]=null;
 		}
 
 		preg_match('/href="\/store\/apps\/developer\?id=(?<id>[^\"]+)"([^\>]+|)>(?<content>[^\<]+)<\/a>/i', $input, $developer);
@@ -102,7 +95,6 @@ class GooglePlay {
 			$values["category"]=trim(strip_tags($category["content"]));
 			$isGame=false;
 			foreach($this->categories["game"] as $game) {
-				// if($values["category"] == $game) {
 				if(strtolower($values["category"]) == strtolower($game)) {
 					$isGame=true;
 					break;


### PR DESCRIPTION
This is the announced "minor rewrite". I've again kept it in separate commits, so it's easier to review (simply walk top-down). Also managed to find the summary, which is kept in protobuf data at the end of the page. Luckily, with a little trick one can convert protobuf to JSON, which I did here. The protobuf structure rarely changes; I'm using that to fetch app permissions: set that up about 5 or 6 years ago, still works.

Speaking of which: permission list I might add with a separate PR later.

PS: Do you insist on tabs – or would you be OK having them replaced by spaces? I won't argue, whatever your answer is: it's your project, so your guidelines matter. Personally and in my projects, I use 2 spaces instead of 1 tab; especially with many nesting levels and long lines, that saves a lot of horizontal scrolling :wink: (don't worry to say you want to stick with tabs; I'd then simply convert back-and-forth as I did up to now)