### PR TITLE
add lang & loc params to parseApplication and parsePerms (see #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ The `grouped` keys are the IDs given to the permission groups by Google. The emp
 
 For results on failure, please see above.
 
+### Obtaining language-specific content
+You want descriptions in your own language? The `parseApplication()` method accepts two optional parameters: your language, and your location (eg for currency). Both should be according to [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), e.g. `en` for English, `de` for German, `fr` for French. The method `parsePerms()` also expects a single language parameter, again using ISO 639-1 specifications.
+
+Note that due to technical limitation, not everything is translated.
+
 
 ### TODO
 

--- a/google-play.php
+++ b/google-play.php
@@ -138,14 +138,14 @@ class GooglePlay {
 
     $perms = $perms_unique = [];
     $json = preg_replace('!.*?(\[.+?\])\s*\d.*!ims','$1',$proto);
-    $arr = json_decode($json)[0][2];
-    foreach (json_decode($arr)[0] as $group) { // 0: group name, 1: group icon, 2: perms, 3: group_id
+    $arr = json_decode(json_decode($json)[0][2]);
+    if (!empty($arr[0])) foreach ($arr[0] as $group) { // 0: group name, 1: group icon, 2: perms, 3: group_id
       $perms[$group[3][0]] = ['group_name'=>$group[0], 'perms'=>$group[2]];
       foreach($group[2] as $perm) $perms_unique[] = $perm[1];
     }
-    if (!empty($misc = json_decode($arr)[1])) {
-      $perms['misc'] = ['group_name'=>$misc[0][0], 'perms'=>$misc[0][2]];
-      foreach($misc[0][2] as $perm) $perms_unique[] = $perm[1];
+    if (!empty($arr[1])) {
+      $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[1][0][2]];
+      foreach($arr[1][0][2] as $perm) $perms_unique[] = $perm[1];
     }
 
     return ['success'=>1,'grouped'=>$perms,'perms'=>array_unique($perms_unique)];

--- a/google-play.php
+++ b/google-play.php
@@ -140,12 +140,18 @@ class GooglePlay {
     $json = preg_replace('!.*?(\[.+?\])\s*\d.*!ims','$1',$proto);
     $arr = json_decode(json_decode($json)[0][2]);
     if (!empty($arr[0])) foreach ($arr[0] as $group) { // 0: group name, 1: group icon, 2: perms, 3: group_id
+      if (empty($group)) continue;
       $perms[$group[3][0]] = ['group_name'=>$group[0], 'perms'=>$group[2]];
       foreach($group[2] as $perm) $perms_unique[] = $perm[1];
     }
     if (!empty($arr[1])) {
       $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[1][0][2]];
       foreach($arr[1][0][2] as $perm) $perms_unique[] = $perm[1];
+    }
+    if (!empty($arr[2])) {
+      if (array_key_exists('misc',$perms)) $perms['misc']['perms'] = array_merge($perms['misc']['perms'],$arr[2]);
+      else $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[2]];
+      foreach($arr[2] as $perm) $perms_unique[] = $perm[1];
     }
 
     return ['success'=>1,'grouped'=>$perms,'perms'=>array_unique($perms_unique)];

--- a/google-play.php
+++ b/google-play.php
@@ -38,7 +38,7 @@ class GooglePlay {
       $values["category"]=trim(strip_tags($category["content"]));
       $catId=trim(strip_tags($category["id"]));
       if($catId=='GAME' || substr($catId,0,5)=='GAME_') $values["type"]="game";
-      elseif($catId=='FAMILY' || substr($catId,0,7)=='FAMILY_') $values["type"]="family";
+      elseif($catId=='FAMILY' || substr($catId,0,7)=='FAMILY?') $values["type"]="family";
       else $values["type"]="app";
     } else {
       $values["category"]=null;

--- a/google-play.php
+++ b/google-play.php
@@ -68,15 +68,21 @@ class GooglePlay {
       $values["images"]=null;
     }
 
-    $values["lastUpdated"] = strip_tags($this->getRegVal('/<div class="BgcNfc">Updated<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
-    $values["versionName"] = strip_tags($this->getRegVal('/<div class="BgcNfc">Current Version<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
-    $values["minimumSDKVersion"] = strip_tags($this->getRegVal('/<div class="hAyfc"><div class="BgcNfc">Requires Android<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
-    $values["installs"] = strip_tags($this->getRegVal('/<div class="hAyfc"><div class="BgcNfc">Installs<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
-    $values["age"] = strip_tags($this->getRegVal('/<div class="hAyfc"><div class="BgcNfc">Content Rating<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb"><div>(?<content>.*?)<\/div>/i'));
+    if (substr(strtolower($lang),0,2)=='en') {
+      $values["lastUpdated"] = strip_tags($this->getRegVal('/<div class="BgcNfc">Updated<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
+      $values["versionName"] = strip_tags($this->getRegVal('/<div class="BgcNfc">Current Version<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
+      $values["minimumSDKVersion"] = strip_tags($this->getRegVal('/<div class="hAyfc"><div class="BgcNfc">Requires Android<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
+      $values["installs"] = strip_tags($this->getRegVal('/<div class="hAyfc"><div class="BgcNfc">Installs<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>.*?)<\/span><\/div><\/span><\/div>/i'));
+      $values["age"] = strip_tags($this->getRegVal('/<div class="hAyfc"><div class="BgcNfc">Content Rating<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb"><div>(?<content>.*?)<\/div>/i'));
+      $values["size"] = $this->getRegVal('/<div class="BgcNfc">Size<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>[^<]+)<\/span>/i');
+    } else {
+      $envals = $this->parseApplication($packageName);
+      foreach(["lastUpdated","versionName","minimumSDKVersion","installs","age","size"] as $val) $values[$val]=$envals[$val];
+    }
+
     $values["rating"] = $this->getRegVal('/<div class="BHMmbe"[^>]*>(?<content>[^<]+)<\/div>/i');
     $values["votes"] = $this->getRegVal('/<span class="AYi5wd TBRnV"><span[^>]*>(?<content>[^>]+)<\/span>/i');
     $values["price"] = $this->getRegVal('/<meta itemprop="price" content="(?<content>[^"]+)">/i');
-    $values["size"] = $this->getRegVal('/<div class="BgcNfc">Size<\/div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">(?<content>[^<]+)<\/span>/i');
 
     if($this->debug) {
       print_r($values);

--- a/google-play.php
+++ b/google-play.php
@@ -76,8 +76,8 @@ class GooglePlay {
     else return null;
   }
 
-  public function parseApplication($packageName) {
-    $link="https://play.google.com/store/apps/details?id=".$packageName."&hl=en_US&gl=US";
+  public function parseApplication($packageName,$lang='en_US',$loc='US') {
+    $link="https://play.google.com/store/apps/details?id=".$packageName."&hl=$lang&gl=$loc";
     if ( ! $this->input = @file_get_contents($link) ) {
       return ['success'=>0,'message'=>'Google returned: '.$http_response_header[0]];
     }
@@ -166,7 +166,7 @@ class GooglePlay {
     return $values;
   }
 
-  public function parsePerms($packageName) {
+  public function parsePerms($packageName,$lang='en') {
     $opts = ['http' => array(
       'method'  => 'POST',
       'header'  => 'Content-type: application/x-www-form-urlencoded;charset=utf-8'
@@ -176,7 +176,7 @@ class GooglePlay {
       )
     ];
     $context  = stream_context_create($opts);
-    if ( $proto = @file_get_contents('https://play.google.com/_/PlayStoreUi/data/batchexecute?rpcids=xdSrCf&bl=boq_playuiserver_20201201.06_p0&hl=en&authuser&soc-app=121&soc-platform=1&soc-device=1&rt=c&f.sid=-8792622157958052111&_reqid=257685', false, $context) ) { // raw proto_buf data
+    if ( $proto = @file_get_contents('https://play.google.com/_/PlayStoreUi/data/batchexecute?rpcids=xdSrCf&bl=boq_playuiserver_20201201.06_p0&hl='.$lang.'&authuser&soc-app=121&soc-platform=1&soc-device=1&rt=c&f.sid=-8792622157958052111&_reqid=257685', false, $context) ) { // raw proto_buf data
       preg_match("!HTTP/1\.\d\s+(\d{3})\s+(.+)$!i",$http_response_header[0],$match);
       $response_code = $match[1];
       switch ($response_code) {

--- a/google-play.php
+++ b/google-play.php
@@ -11,64 +11,6 @@
 **/
 class GooglePlay {
   private $debug=false;
-  private $categories=[
-    "app"=>[
-      "Art & Design",
-      "Augmented Reality",
-      "Auto & Vehicles",
-      "Beauty",
-      "Books & Reference",
-      "Business",
-      "Comics",
-      "Communication",
-      "Dating",
-      "Daydream",
-      "Education",
-      "Entertainment",
-      "Events",
-      "Finance",
-      "Food & Drink",
-      "Health & Fitness",
-      "House & Home",
-      "Libraries & Demo",
-      "Lifestyle",
-      "Maps & Navigation",
-      "Medical",
-      "Music & Audio",
-      "News & Magazines",
-      "Parenting",
-      "Personalization",
-      "Photography",
-      "Productivity",
-      "Shopping",
-      "Social",
-      "Sports",
-      "Tools",
-      "Travel & Local",
-      "Video Players & Editors",
-      "Wear OS by Google",
-      "Weather",
-    ],
-    "game"=>[
-      "Action",
-      "Adventure",
-      "Arcade",
-      "Board",
-      "Card",
-      "Casino",
-      "Casual",
-      "Educational",
-      "Music",
-      "Puzzle",
-      "Racing",
-      "Role Playing",
-      "Simulation",
-      "Sports",
-      "Strategy",
-      "Trivia",
-      "Word",
-    ],
-  ];
 
   protected function getRegVal($regEx) {
     preg_match($regEx, $this->input, $res);
@@ -94,14 +36,10 @@ class GooglePlay {
     preg_match('/itemprop="genre" href="\/store\/apps\/category\/(?<id>[^\"]+)"([^\>]+|)>(?<content>[^\<]+)<\/a><\/span>/i', $this->input, $category);
     if(isset($category["id"], $category["content"])) {
       $values["category"]=trim(strip_tags($category["content"]));
-      $isGame=false;
-      foreach($this->categories["game"] as $game) {
-        if(strtolower($values["category"]) == strtolower($game)) {
-          $isGame=true;
-          break;
-        }
-      }
-      $values["type"]=$isGame ? "game" : "app";
+      $catId=trim(strip_tags($category["id"]));
+      if($catId=='GAME' || substr($catId,0,5)=='GAME_') $values["type"]="game";
+      elseif($catId=='FAMILY' || substr($catId,0,7)=='FAMILY_') $values["type"]="family";
+      else $values["type"]="app";
     } else {
       $values["category"]=null;
       $values["type"]=null;

--- a/google-play.php
+++ b/google-play.php
@@ -143,6 +143,10 @@ class GooglePlay {
       $perms[$group[3][0]] = ['group_name'=>$group[0], 'perms'=>$group[2]];
       foreach($group[2] as $perm) $perms_unique[] = $perm[1];
     }
+    if (!empty($misc = json_decode($arr)[1])) {
+      $perms['misc'] = ['group_name'=>$misc[0][0], 'perms'=>$misc[0][2]];
+      foreach($misc[0][2] as $perm) $perms_unique[] = $perm[1];
+    }
 
     return ['success'=>1,'grouped'=>$perms,'perms'=>array_unique($perms_unique)];
   }


### PR DESCRIPTION
Adding the parameters is easy. Dealing with the results seems a different thing:

* `parsePerms()`: Groups are translated, permissions somehow not
* `parseApplication()`: translations are shipped where available, but not always as expected. Tried with `de`:
  * `com.twidere.twiderex`, `com.keramidas.TitaniumBackup`: German description appended to the English one, separated by `<div jsname="Igi1ac" style="display:none;">` (and yes, it's the translation that's marked by `display:none`)
  * `com.bezapps.flowdiademo`, `com.colnix.fta`: German description as expected
  * summary (if not "temporarily missing") and category seem always to translated correctly

But your "game matching" (`type`) will fail for everything but English, which results in "no games, all apps"; this might be alleviated by instead of the "visible description" that array would build upon the `basename($url)`, like `/store/apps/category/PRODUCTIVITY`=>'PRODUCTIVITY' – and matching that against `$id`. That would require redefining `private $categories`.

Please check for yourself and say what you think. I've marked this WIP as at least the "type matching" should be resolved before merging. Further I'm not sure whether those "appended translations" should be dealt with; a

```php
$description = preg_replace('!.*<div jsname="Igi1ac" style="display:none;">(.*)!ims','$1',$description)`;
```

could do that (and leave the string untouched when that DIV is not present).

closes #8 