### PR TITLE
parsePerms(): work around broken ProtoBuf for some (very few) apps

### DIFF
--- a/google-play.php
+++ b/google-play.php
@@ -295,7 +295,7 @@ class GooglePlay {
     if (!empty($arr[2])) {
       if (array_key_exists('misc',$perms)) $perms['misc']['perms'] = array_merge($perms['misc']['perms'],$arr[2]);
       elseif ( is_array ($arr[1]) && is_array($arr[1][0]) && !empty($arr[1][0][0]) ) $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[2]];
-      else $perms['misc'] = [];
+      else $perms['misc'] = ['group_name'=>'unknown', 'perms'=>$arr[2]]; // ProtoBuf broken for this app, e.g. com.achunt.weboslauncher (perms display broken on Play website itself)
       foreach($arr[2] as $perm) $perms_unique[] = $perm[1];
     }
 

--- a/google-play.php
+++ b/google-play.php
@@ -294,7 +294,7 @@ class GooglePlay {
     }
     if (!empty($arr[2])) {
       if (array_key_exists('misc',$perms)) $perms['misc']['perms'] = array_merge($perms['misc']['perms'],$arr[2]);
-      elseif ( is_array($arr[1][0]) && !empty($arr[1][0][0]) ) $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[2]];
+      elseif ( is_array ($arr[1]) && is_array($arr[1][0]) && !empty($arr[1][0][0]) ) $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[2]];
       else $perms['misc'] = [];
       foreach($arr[2] as $perm) $perms_unique[] = $perm[1];
     }

--- a/google-play.php
+++ b/google-play.php
@@ -294,7 +294,8 @@ class GooglePlay {
     }
     if (!empty($arr[2])) {
       if (array_key_exists('misc',$perms)) $perms['misc']['perms'] = array_merge($perms['misc']['perms'],$arr[2]);
-      else $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[2]];
+      elseif ( is_array($arr[1][0]) && !empty($arr[1][0][0]) ) $perms['misc'] = ['group_name'=>$arr[1][0][0], 'perms'=>$arr[2]];
+      else $perms['misc'] = [];
       foreach($arr[2] as $perm) $perms_unique[] = $perm[1];
     }
 


### PR DESCRIPTION
Looks like there are rare conditions with "misc" perms having no group name. This commit should mitigate that hopefully. Maybe wait a day or two before merging: I've just put it to production here so it hopefully gets confirmed (at least to have no side-effects :wink:)