### PR TITLE
parseVersion: catch (rare) error when Google returns no version info

### DIFF
--- a/google-play.php
+++ b/google-play.php
@@ -83,10 +83,10 @@ class GooglePlay {
       preg_match("!HTTP/1\.\d\s+(\d{3})\s+(.+)$!i", $http_response_header[0], $match);
       $response_code = $match[1];
       switch ($response_code) {
-        case "200" : // HTTP/1.0 200 OK
+        case '200' : // HTTP/1.0 200 OK
           break;
-        case "400" : // echo "! No XHR for '$pkg'\n";
-        case "404" : // app no longer on play
+        case '400' : // echo "! No XHR for '$pkg'\n";
+        case '404' : // app no longer on play
         default:
           return ['packageName'=>$packageName, 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>$http_response_header[0]];
           break;
@@ -103,10 +103,10 @@ class GooglePlay {
     if ( gettype($verInfo) == 'NULL' ) { // happens rarely, but happens
       return ['packageName'=>$packageName, 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'Google returned no version info'];
     } else {
-      $values["packageName"] = $packageName;
-      $values["versionName"] = $verInfo[1];
-      $values["minimumSDKVersion"] = $verInfo[2];
-      $values["size"] = $verInfo[0];
+      $values['packageName'] = $packageName;
+      $values['versionName'] = $verInfo[1];
+      $values['minimumSDKVersion'] = $verInfo[2];
+      $values['size'] = $verInfo[0];
       $values['success'] = 1;
       $values['message'] = $message;
     }

--- a/google-play.php
+++ b/google-play.php
@@ -88,11 +88,11 @@ class GooglePlay {
         case "400" : // echo "! No XHR for '$pkg'\n";
         case "404" : // app no longer on play
         default:
-          return ['packageName'=>'', 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>$http_response_header[0]];
+          return ['packageName'=>$packageName, 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>$http_response_header[0]];
           break;
       }
     } else { // network error (e.g. "failed to open stream: Connection timed out")
-      return ['packageName'=>'', 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'network error'];
+      return ['packageName'=>$packageName, 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'network error'];
     }
 
     $proto = preg_replace('!^\)]}.*?\n!','',$proto);
@@ -100,10 +100,10 @@ class GooglePlay {
     $values = [];
     $message = '';
 
-    $values["packageName"] = $packageName;
     if ( gettype($verInfo) == 'NULL' ) { // happens rarely, but happens
-      return ['packageName'=>'', 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'Google returned no version info'];
+      return ['packageName'=>$packageName, 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'Google returned no version info'];
     } else {
+      $values["packageName"] = $packageName;
       $values["versionName"] = $verInfo[1];
       $values["minimumSDKVersion"] = $verInfo[2];
       $values["size"] = $verInfo[0];

--- a/google-play.php
+++ b/google-play.php
@@ -100,7 +100,7 @@ class GooglePlay {
     $values = [];
     $message = '';
 
-    if ( gettype($verInfo) == 'NULL' ) { // happens rarely, but happens
+    if ( gettype($verInfo) == 'NULL' ) { // happens rarely, but happens; on a subsequent call for the same package it might succeed (temp hick-up?)
       return ['packageName'=>$packageName, 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'Google returned no version info'];
     } else {
       $values['packageName'] = $packageName;

--- a/google-play.php
+++ b/google-play.php
@@ -88,11 +88,11 @@ class GooglePlay {
         case "400" : // echo "! No XHR for '$pkg'\n";
         case "404" : // app no longer on play
         default:
-          return ['success'=>0, 'grouped'=>[], 'perms'=>[], 'message'=>$http_response_header[0]];
+          return ['packageName'=>'', 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>$http_response_header[0]];
           break;
       }
     } else { // network error (e.g. "failed to open stream: Connection timed out")
-      return ['success'=>0, 'grouped'=>[], 'perms'=>[], 'message'=>'network error'];
+      return ['packageName'=>'', 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'network error'];
     }
 
     $proto = preg_replace('!^\)]}.*?\n!','',$proto);
@@ -101,11 +101,15 @@ class GooglePlay {
     $message = '';
 
     $values["packageName"] = $packageName;
-    $values["versionName"] = $verInfo[1];
-    $values["minimumSDKVersion"] = $verInfo[2];
-    $values["size"] = $verInfo[0];
-    $values['success'] = 1;
-    $values['message'] = $message;
+    if ( gettype($verInfo) == 'NULL' ) { // happens rarely, but happens
+      return ['packageName'=>'', 'versionName'=>'', 'minimumSDKVersion'=>0, 'size'=>0, 'success'=>0, 'message'=>'Google returned no version info'];
+    } else {
+      $values["versionName"] = $verInfo[1];
+      $values["minimumSDKVersion"] = $verInfo[2];
+      $values["size"] = $verInfo[0];
+      $values['success'] = 1;
+      $values['message'] = $message;
+    }
 
     return $values;
   }


### PR DESCRIPTION
another rare one: Google sometimes returns no version info, which then caused some PHP Notices to be thrown. While on it I also noticed details returned on 400/404 were incorrect (copy-pasta error) and fixed that along.

Setting it to DRAFT for now as I first try to reproduce (again, hard to find a candidate as it happens  for approx. 1 out of 3.000 apps – had it 3 times yesterday, but could not reproduce today despite of running 500+ apps through it). Like last time, I'll signal when I was able to confirm; feel free to ping me if you don't hear back for a week or so :wink: