### PR TITLE
including reviews with app details

### DIFF
--- a/google-play.php
+++ b/google-play.php
@@ -220,7 +220,7 @@ class GooglePlay {
       if ( !empty($data["aggregateRating"]["ratingCount"]) ) $values["votes"] = $data["aggregateRating"]["ratingCount"];
     }
 
-    $limit = 5; $proto = ''; $proto2 = '';
+    $limit = 5; $proto = '';
     while ( empty($proto) && $limit > 0 ) { // sometimes protobuf is missing, but present again on subsequent call
       $proto  = json_decode($this->getRegVal("/key: 'ds:4'. hash: '7'. data:(?<content>\[\[\[.+?). sideChannel: .*?\);<\/script/ims")); // DataSource:4 = featureGraphic, video, summary
       if ( empty($proto) || empty($proto[1]) ) {

--- a/google-play.php
+++ b/google-play.php
@@ -244,17 +244,20 @@ class GooglePlay {
         $r["review_id"] = $rev[0];
         $r["reviewed_version"] = $rev[10];
         $r["review_date"] = $rev[5][0];
-        $r["text"]  = $rev[4];
+        $r["review_text"]  = $rev[4];
         $r["stars"] = $rev[2];
-        $r["thumbs"] = $rev[6];
+        $r["like_count"] = $rev[6];
         $r["reviewer"] = [
-          "id"=>$rev[9][0],
+          "reviewer_id"=>$rev[9][0],
           "name"=>$rev[9][1],
           "avatar"=>$rev[9][3][0][3][2],
           "bg_image"=>$rev[9][4][3][2]
         ];
         $values["reviews"][] = $r;
       }
+      $values["review_token"] = $proto[1][1]; // needed if we want to fetch more reviews later
+    } else {
+      $values["review_token"] = '';
     }
 
     if ($this->debug) {

--- a/google-play.php
+++ b/google-play.php
@@ -253,6 +253,15 @@ class GooglePlay {
           "avatar"=>$rev[9][3][0][3][2],
           "bg_image"=>$rev[9][4][3][2]
         ];
+        if ( empty($rev[7]) ) {
+          $r["reply"] = [];
+        } else {
+          $r["response"] = [
+            "responder_name"=>$rev[7][0],
+            "response_text"=>$rev[7][1],
+            "response_date"=>$rev[7][2][0]
+          ];
+        }
         $values["reviews"][] = $r;
       }
       $values["review_token"] = $proto[1][1]; // needed if we want to fetch more reviews later


### PR DESCRIPTION
As they are part of the page and don't need a separate request, I've left them with the app details. Might be incomplete, though: I've noticed when browsing them at Play, it seems to have loaded more via XHR all the while. For the example you've specified in #27 it has 40 reviews included. If that's not enough and there are more, we could take a look at that for a separate method later. This one at least gets you started :smile:

So can you please test it out and give your opinion, @BaseMax?