### PR TITLE
avoid PHP notice when review token is not available

### DIFF
--- a/google-play.php
+++ b/google-play.php
@@ -278,7 +278,7 @@ class GooglePlay {
         }
         $values["reviews"][] = $r;
       }
-      $values["review_token"] = $proto[1][1]; // needed if we want to fetch more reviews later
+      $values["review_token"] = @$proto[1][1] ?: ''; // needed if we want to fetch more reviews later (not always set)
     } else {
       $values["review_token"] = '';
     }


### PR DESCRIPTION
Doesn't happen that often, so this slipped through with the release :see_no_evil: